### PR TITLE
fix: rx collections observer effect

### DIFF
--- a/lib/rx_notifier.dart
+++ b/lib/rx_notifier.dart
@@ -26,6 +26,9 @@ mixin _Transparent<T> on ValueListenable<T> {
   @override
   get value {
     _rxMainContext.reportRead(this);
+    if (super.value is Listenable) {
+      _rxMainContext.reportRead(super.value as Listenable);
+    }
     return super.value;
   }
 }

--- a/test/collections/rx_list_test.dart
+++ b/test/collections/rx_list_test.dart
@@ -16,8 +16,34 @@ main() {
     list.add('novo 2');
     await Future.delayed(Duration(milliseconds: 800));
   });
-  test('rx containe', () async {
+  test('rx contains', () async {
     RxList list = RxList(['jacob', 'sara']);
-    print(list.contains('jacob'));
+    assert(list.contains('jacob'));
+  });
+
+  test('rx list observer effect', () async {
+    final list = RxNotifier(RxList(['jacob', 'sara']));
+    bool effectHappened = false;
+    rxObserver(() => list.value, effect: (val) {
+      effectHappened = list.value.contains('coco');
+    });
+    list.value.add('coco');
+    assert(effectHappened);
+  });
+
+  test('replace rxlist and keep reactivity', () async {
+    final list = RxNotifier(RxList(['jacob', 'sara']));
+    bool effectHappened = false;
+    bool ignoreFirstReaction = true;
+    rxObserver(() => list.value, effect: (val) {
+      if (ignoreFirstReaction) {
+        ignoreFirstReaction = false;
+        return;
+      }
+      effectHappened = list.value.contains('coco');
+    });
+    list.value = RxList();
+    list.value.add('coco');
+    assert(effectHappened);
   });
 }


### PR DESCRIPTION
Hope this is enough to solve this issue. I created a new test.

I also remembered another issue i had, that when replacing a notifier value with a new RxCollection object, the reactivity is lost, and I havent found a solution for this issue yet. I made a test for this as well, but it will fail atm. 

Personally I have stopped using the RxCollection objects as it is a little confusing as one is forced to use clear, and add to be able to replace the value. If the value is replaced with a new RxList, the reactivity is lost. I like the mentallity of Immutability and this issue breaks that behaviour.