### PR TITLE
Fix disposers list cleaning before disposing all `RxDisposer`s

### DIFF
--- a/rx_notifier/lib/rx_notifier.dart
+++ b/rx_notifier/lib/rx_notifier.dart
@@ -156,8 +156,8 @@ abstract class RxReducer {
   void dispose() {
     for (final disposer in _rxDisposers) {
       disposer();
-      _rxDisposers.clear();
     }
+    _rxDisposers.clear();
   }
 }
 


### PR DESCRIPTION
The disposers list was getting cleaned before all disposers were disposed.

This commit move `_rxDisposers.clear()` after calling all disposers in the for loop.